### PR TITLE
Fix Windows gray screen when opening biome files

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { PanelLayout } from "@/components/layout/PanelLayout";
 import { DragGhost } from "@/components/editor/DragGhost";
 import { HomeScreen } from "@/components/home/HomeScreen";
 import { Toast } from "@/components/ui/Toast";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { ConfirmDialog } from "@/components/dialogs/ConfirmDialog";
 import { saveRef } from "@/utils/saveRef";
 
@@ -137,7 +138,9 @@ export default function App() {
     <ReactFlowProvider>
       <div className="flex flex-col h-screen bg-tn-bg text-tn-text">
         <Toolbar onCloseProject={requestCloseProject} />
-        <PanelLayout />
+        <ErrorBoundary>
+          <PanelLayout />
+        </ErrorBoundary>
         <StatusBar />
       </div>
       <DragGhost />

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,50 @@
+import { Component } from "react";
+import type { ErrorInfo, ReactNode } from "react";
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error("ErrorBoundary caught:", error, info.componentStack);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex flex-1 items-center justify-center bg-tn-bg text-tn-text">
+          <div className="text-center space-y-4 max-w-md px-4">
+            <h2 className="text-lg font-semibold">Something went wrong</h2>
+            <p className="text-sm text-tn-text-secondary break-words">
+              {this.state.error?.message ?? "An unexpected error occurred."}
+            </p>
+            <button
+              type="button"
+              className="px-4 py-2 rounded bg-tn-accent text-white text-sm hover:opacity-90"
+              onClick={() => this.setState({ hasError: false, error: null })}
+            >
+              Try Again
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/hooks/useTauriIO.ts
+++ b/src/hooks/useTauriIO.ts
@@ -365,8 +365,9 @@ export function useTauriIO() {
           // Try to load ContentFields from sibling WorldStructures/MainWorld.json
           let contentFields: Record<string, number> | undefined;
           try {
-            const biomeDir = filePath.replace(/[/\\][^/\\]+$/, "");
-            const parentDir = biomeDir.replace(/[/\\][^/\\]+$/, "");
+            const normalized = filePath.replace(/\\/g, "/");
+            const biomeDir = normalized.replace(/\/[^/]+$/, "");
+            const parentDir = biomeDir.replace(/\/[^/]+$/, "");
             const worldStructurePath = `${parentDir}/WorldStructures/MainWorld.json`;
             const wsContent = await readAssetFile(worldStructurePath);
             if (wsContent && typeof wsContent === "object") {

--- a/src/utils/fileTypeDetection.ts
+++ b/src/utils/fileTypeDetection.ts
@@ -8,7 +8,8 @@ import type { Node } from "@xyflow/react";
 export function isBiomeFile(content: Record<string, unknown>, filePath: string): boolean {
   if ("Type" in content) return false;
   if ("Terrain" in content) return true;
-  return filePath.toLowerCase().includes("/biomes/");
+  const p = filePath.toLowerCase();
+  return p.includes("/biomes/") || p.includes("\\biomes\\");
 }
 
 /**


### PR DESCRIPTION
## Summary

- Normalize backslash path separators in `isBiomeFile()` and WorldStructure sibling path construction so biome files are correctly identified and loaded on Windows
- Add a React `ErrorBoundary` around `PanelLayout` to catch render crashes gracefully instead of blanking the entire UI

## Test plan

- [ ] Open the app on Windows, load an asset pack, and click a biome file — should render the biome graph instead of a gray screen
- [ ] Verify `ErrorBoundary` works: temporarily throw in a component and confirm the fallback UI appears
- [ ] On macOS: confirm no regressions — biome files still open correctly