### PR TITLE
Fix biome render crash on object field values

### DIFF
--- a/src/nodes/density/NoiseNodes.tsx
+++ b/src/nodes/density/NoiseNodes.tsx
@@ -19,7 +19,7 @@ function NoiseNodeBody({ data, fields }: { data: { fields: Record<string, any> }
       {fields.map((f) => (
         <div key={f} className="flex justify-between">
           <span className="text-tn-text-muted">{labels[f] ?? f}</span>
-          <span>{data.fields[f] ?? "—"}</span>
+          <span>{typeof data.fields[f] === "object" ? JSON.stringify(data.fields[f]) : (data.fields[f] ?? "—")}</span>
         </div>
       ))}
     </div>


### PR DESCRIPTION
## Summary

- Fix React error #31 crash when opening biome files containing noise nodes with object-typed field values (e.g. `{x, y, z}` coordinates)
- `NoiseNodeBody` now stringifies object values instead of rendering them directly as React children

## Test plan

- [ ] Open an asset pack and click a biome file with noise nodes — should render without crashing
- [ ] Verify scalar field values (numbers, strings) still display correctly