### PR TITLE
fix: resolve Material tab crash on blank/void template projects

### DIFF
--- a/src-tauri/src/commands/io.rs
+++ b/src-tauri/src/commands/io.rs
@@ -146,7 +146,7 @@ pub fn create_blank_project(target_path: String) -> Result<(), String> {
         },
         "MaterialProvider": {
             "Type": "Constant",
-            "Material": { "Solid": "stone", "Fluid": "", "SolidBottomUp": false }
+            "Material": "stone"
         },
         "Props": [],
         "EnvironmentProvider": { "Type": "Constant", "Environment": "default" },

--- a/src/components/properties/layers/InteractiveLayerCard.tsx
+++ b/src/components/properties/layers/InteractiveLayerCard.tsx
@@ -19,7 +19,8 @@ export function InteractiveLayerCard({
   onDragStart: (e: React.PointerEvent) => void;
 }) {
   const [typeOpen, setTypeOpen] = useState(false);
-  const color = MATERIAL_COLORS[layer.material.toLowerCase()] ?? "#666";
+  const materialName = typeof layer.material === "string" ? layer.material : "unknown";
+  const color = MATERIAL_COLORS[materialName.toLowerCase()] ?? "#666";
 
   return (
     <div className="flex items-center gap-1.5 p-2 rounded border border-tn-border bg-white/[0.02] transition-all duration-150 hover:border-white/20 hover:bg-white/5">
@@ -43,13 +44,13 @@ export function InteractiveLayerCard({
         onClick={onClick}
         className="w-6 h-6 rounded shrink-0 border border-white/10 hover:border-white/30 transition-colors"
         style={{ backgroundColor: color }}
-        title={`Select ${layer.material}`}
+        title={`Select ${materialName}`}
       />
 
       {/* Info */}
       <div onClick={onClick} className="flex-1 min-w-0 text-left cursor-pointer" role="button" tabIndex={0}>
         <div className="text-xs font-medium text-tn-text capitalize truncate">
-          {layer.material}
+          {materialName}
         </div>
         <div className="flex items-center gap-1.5 mt-0.5">
           {/* Layer type badge */}

--- a/src/components/properties/layers/V1ReadOnlyView.tsx
+++ b/src/components/properties/layers/V1ReadOnlyView.tsx
@@ -14,7 +14,8 @@ function RoleBadge({ role }: { role: string }) {
 }
 
 function ReadOnlyLayerCard({ layer, onClick }: { layer: MaterialLayer; onClick: () => void }) {
-  const color = MATERIAL_COLORS[layer.material.toLowerCase()] ?? "#666";
+  const materialName = typeof layer.material === "string" ? layer.material : "unknown";
+  const color = MATERIAL_COLORS[materialName.toLowerCase()] ?? "#666";
 
   return (
     <button
@@ -27,7 +28,7 @@ function ReadOnlyLayerCard({ layer, onClick }: { layer: MaterialLayer; onClick: 
       />
       <div className="flex-1 min-w-0">
         <div className="text-xs font-medium text-tn-text capitalize">
-          {layer.material}
+          {materialName}
         </div>
         <div className="flex items-center gap-1.5 mt-0.5">
           <RoleBadge role={layer.role} />

--- a/src/hooks/useTauriIO.ts
+++ b/src/hooks/useTauriIO.ts
@@ -98,7 +98,7 @@ async function extractBiomeSections(
   // MaterialProvider → graph entire subtree
   const matProvider = wrapper.MaterialProvider;
   if (matProvider && typeof matProvider === "object" && "Type" in (matProvider as Record<string, unknown>)) {
-    const { nodes, edges } = jsonToGraph(matProvider as Record<string, unknown>, 0, 0, "mat");
+    const { nodes, edges } = jsonToGraph(matProvider as Record<string, unknown>, 0, 0, "mat", "MaterialProvider");
     let matOutputId: string | null = null;
     if (nodes.length > 0) {
       const rootNode = nodes[nodes.length - 1];

--- a/src/utils/__tests__/biomeSectionUtils.test.ts
+++ b/src/utils/__tests__/biomeSectionUtils.test.ts
@@ -237,6 +237,17 @@ describe("extractMaterialLayers — V1", () => {
   it("returns empty for no nodes", () => {
     expect(extractMaterialLayers([], [])).toHaveLength(0);
   });
+
+  it("handles object-form Material (Hytale { Solid, Fluid } format)", () => {
+    const nodes = [
+      makeNode("c", "Constant", {
+        Material: { Solid: "stone", Fluid: "", SolidBottomUp: false },
+      }),
+    ];
+    const layers = extractMaterialLayers(nodes, []);
+    expect(layers).toHaveLength(1);
+    expect(layers[0].material).toBe("stone");
+  });
 });
 
 /* ── extractMaterialLayers (V2) ────────────────────────────────────── */
@@ -311,6 +322,23 @@ describe("extractMaterialLayers — V2", () => {
     expect(layers).toHaveLength(1);
     expect(layers[0].material).toBe("stone");
     expect(layers[0].layerIndex).toBe(0);
+  });
+
+  it("handles object-form Material in V2 layer Constant node", () => {
+    const nodes = [
+      makeNode("sad", "SpaceAndDepth", { LayerContext: "DEPTH_INTO_FLOOR", MaxExpectedDepth: 16 }),
+      makeNode("layer0", "ConstantThickness", { Thickness: 3 }),
+      makeNode("mat0", "Constant", {
+        Material: { Solid: "dirt", Fluid: "", SolidBottomUp: false },
+      }),
+    ];
+    const edges = [
+      makeEdge("layer0", "sad", "Layers[0]"),
+      makeEdge("mat0", "layer0", "Material"),
+    ];
+    const layers = extractMaterialLayers(nodes, edges);
+    expect(layers).toHaveLength(1);
+    expect(layers[0].material).toBe("dirt");
   });
 
   it("handles V2 layer with no material edge", () => {

--- a/src/utils/biomeSectionUtils.ts
+++ b/src/utils/biomeSectionUtils.ts
@@ -228,6 +228,19 @@ export function matchMaterialColor(name: string): string {
 }
 
 /**
+ * Normalize a Material field that may be either a plain string ("stone")
+ * or the Hytale object form ({ Solid: "stone", Fluid: "", SolidBottomUp: false }).
+ */
+function resolveMaterialField(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value && typeof value === "object") {
+    const obj = value as Record<string, unknown>;
+    if (typeof obj.Solid === "string" && obj.Solid.length > 0) return obj.Solid;
+  }
+  return "unknown";
+}
+
+/**
  * Walk the MaterialProvider graph from root to extract material layers.
  * Handles Conditional, SpaceAndDepth (V1 Solid/Empty + V2 Layers[]),
  * HeightGradient, and Constant nodes.
@@ -288,7 +301,7 @@ export function extractMaterialLayers(
         if (matType === "Constant") {
           layers.push({
             nodeId: materialSrc,
-            material: (matFields.Material as string) ?? "unknown",
+            material: resolveMaterialField(matFields.Material),
             role: `Layer ${layerIndex}`,
             depth: maxDepth,
             parentType: layerType,
@@ -328,7 +341,7 @@ export function extractMaterialLayers(
     if (type === "Constant") {
       layers.push({
         nodeId,
-        material: (fields.Material as string) ?? "unknown",
+        material: resolveMaterialField(fields.Material),
         role,
         depth,
         parentType: type,

--- a/src/utils/jsonToGraph.ts
+++ b/src/utils/jsonToGraph.ts
@@ -106,7 +106,7 @@ function resolveNodeType(assetType: string, parentFieldName?: string): string {
  * Convert a V2 JSON asset into React Flow nodes and edges.
  * Nested assets become separate nodes connected by edges.
  */
-export function jsonToGraph(json: V2Asset, startX = 0, startY = 0, idPrefix = "graph"): GraphResult {
+export function jsonToGraph(json: V2Asset, startX = 0, startY = 0, idPrefix = "graph", rootParentField?: string): GraphResult {
   let localCounter = 0;
   const nodes: Node[] = [];
   const edges: Edge[] = [];
@@ -190,6 +190,6 @@ export function jsonToGraph(json: V2Asset, startX = 0, startY = 0, idPrefix = "g
     return nodeId;
   }
 
-  processAsset(json, startX, startY);
+  processAsset(json, startX, startY, rootParentField);
   return { nodes, edges };
 }

--- a/templates/void/HytaleGenerator/Biomes/VoidBiome.json
+++ b/templates/void/HytaleGenerator/Biomes/VoidBiome.json
@@ -9,11 +9,7 @@
   },
   "MaterialProvider": {
     "Type": "Constant",
-    "Material": {
-      "Solid": "stone",
-      "Fluid": "",
-      "SolidBottomUp": false
-    }
+    "Material": "stone"
   },
   "Props": [],
   "EnvironmentProvider": {


### PR DESCRIPTION
## Summary

Fixes the Material tab crash (`layer.material.toLowerCase is not a function`) when opening blank or void template projects. Closes #5.

- **Object-form Material field**: Blank and void templates used the Hytale object form `{ Solid, Fluid, SolidBottomUp }` for Material instead of a plain string. Added `resolveMaterialField()` helper to normalize either format, and changed both templates to use the string form.
- **Wrong node type on canvas**: `jsonToGraph` lacked a root category context for the MaterialProvider section, so the root Constant node rendered as a density node (teal) instead of a material node (orange). Added `rootParentField` parameter and pass `"MaterialProvider"` when graphing the section.
- **Defensive UI guards**: Added runtime type checks in `InteractiveLayerCard` and `V1ReadOnlyView` so `.toLowerCase()` is never called on a non-string.

## Test plan

- [x] `npx vitest run src/utils/__tests__/biomeSectionUtils.test.ts` — 27/27 pass (2 new)
- [ ] Create a blank project → open DefaultBiome → click Materials tab → no crash, shows "stone" as `Material:Constant` (orange node)
- [ ] Create a void project → same behavior
- [ ] Open forest-hills biome → Materials tab still works (regression check)
- [ ] Edit material in blank project, save, reload → material persists correctly