### PR TITLE
fix: resolve noise settings + redesign biome editor for large sets

### DIFF
--- a/src/components/editor/BiomeRangeEditor.tsx
+++ b/src/components/editor/BiomeRangeEditor.tsx
@@ -1,57 +1,179 @@
-import { useCallback, useRef, useMemo } from "react";
+import { useCallback, useRef, useMemo, useState } from "react";
 import { useEditorStore } from "@/stores/editorStore";
 import { useProjectStore } from "@/stores/projectStore";
 
-const BIOME_COLORS = [
-  "#5AACA6", // patina
-  "#A67EB8", // amethyst
-  "#7a9e68", // moss
-  "#C87D3A", // copper
-  "#B8648B", // heather
-  "#D4A843", // sandstone
-  "#5B8DBF", // slate blue
-  "#C76B6B", // terra cotta
-];
-
 const MIN_GAP = 0.02;
-const HANDLE_WIDTH = 8;
-const AXIS_PADDING = 24; // px padding on each side of the axis
+const ROW_H = 28;
 
-interface DragState {
-  type: "move" | "resize-min" | "resize-max";
-  index: number;
-  startX: number;
-  originalMin: number;
-  originalMax: number;
+type SortKey = "name" | "min" | "max" | "width";
+type SortDir = "asc" | "desc";
+
+/** Deterministic HSL color from biome name */
+function biomeColor(name: string): string {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = ((hash << 5) - hash + name.charCodeAt(i)) | 0;
+  }
+  const h = ((hash % 360) + 360) % 360;
+  return `hsl(${h}, 58%, 58%)`;
 }
 
-interface Overlap {
-  i: number;
-  j: number;
+/** Map a noise value [-1,1] to a percentage */
+function pct(v: number): number {
+  return ((v + 1) / 2) * 100;
+}
+
+// ---------------------------------------------------------------------------
+// Coverage overview strip — thin bar showing all biome ranges overlaid
+// ---------------------------------------------------------------------------
+function CoverageStrip({
+  ranges,
+  selectedIndex,
+  onSelect,
+}: {
+  ranges: { Biome: string; Min: number; Max: number }[];
+  selectedIndex: number | null;
+  onSelect: (i: number) => void;
+}) {
+  return (
+    <div className="relative h-6 bg-black/20 rounded overflow-hidden">
+      {/* Axis gridlines */}
+      {[-0.5, 0, 0.5].map((v) => (
+        <div
+          key={v}
+          className="absolute top-0 bottom-0 w-px bg-white/[0.06]"
+          style={{ left: `${pct(v)}%` }}
+        />
+      ))}
+      {/* Biome bars */}
+      {ranges.map((r, i) => {
+        const left = pct(r.Min);
+        const width = pct(r.Max) - left;
+        const color = biomeColor(r.Biome);
+        const isSel = i === selectedIndex;
+        return (
+          <div
+            key={i}
+            className="absolute top-0 bottom-0 cursor-pointer transition-opacity hover:opacity-100"
+            style={{
+              left: `${left}%`,
+              width: `${width}%`,
+              minWidth: 3,
+              backgroundColor: color,
+              opacity: isSel ? 0.95 : 0.4,
+              outline: isSel ? `2px solid ${color}` : undefined,
+              outlineOffset: -1,
+              zIndex: isSel ? 10 : undefined,
+            }}
+            onClick={() => onSelect(i)}
+            title={`${r.Biome}  [${r.Min.toFixed(2)}, ${r.Max.toFixed(2)}]`}
+          />
+        );
+      })}
+      {/* Axis labels */}
+      <span className="absolute left-1 top-0.5 text-[8px] text-white/30 pointer-events-none leading-none">-1</span>
+      <span className="absolute right-1 top-0.5 text-[8px] text-white/30 pointer-events-none leading-none">1</span>
+      <span className="absolute top-0.5 text-[8px] text-white/30 pointer-events-none leading-none" style={{ left: "50%", transform: "translateX(-50%)" }}>0</span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Inline mini range bar for each list row
+// ---------------------------------------------------------------------------
+function MiniRangeBar({
+  min,
+  max,
+  color,
+  isSelected,
+  onDragMin,
+  onDragMax,
+  onDragMove,
+}: {
   min: number;
   max: number;
+  color: string;
+  isSelected: boolean;
+  onDragMin: (delta: number) => void;
+  onDragMax: (delta: number) => void;
+  onDragMove: (delta: number) => void;
+}) {
+  const barRef = useRef<HTMLDivElement>(null);
+
+  const startDrag = useCallback(
+    (e: React.PointerEvent, mode: "min" | "max" | "move") => {
+      e.stopPropagation();
+      e.preventDefault();
+      (e.target as HTMLElement).setPointerCapture(e.pointerId);
+      const startX = e.clientX;
+
+      const onMove = (ev: PointerEvent) => {
+        if (!barRef.current) return;
+        const barWidth = barRef.current.getBoundingClientRect().width;
+        const dxPx = ev.clientX - startX;
+        const dValue = (dxPx / barWidth) * 2; // bar represents -1 to 1 → width = 2
+        if (mode === "min") onDragMin(dValue);
+        else if (mode === "max") onDragMax(dValue);
+        else onDragMove(dValue);
+      };
+
+      const onUp = (ev: PointerEvent) => {
+        (ev.target as HTMLElement).releasePointerCapture(ev.pointerId);
+        document.removeEventListener("pointermove", onMove);
+        document.removeEventListener("pointerup", onUp);
+      };
+
+      document.addEventListener("pointermove", onMove);
+      document.addEventListener("pointerup", onUp);
+    },
+    [onDragMin, onDragMax, onDragMove],
+  );
+
+  const left = pct(min);
+  const width = pct(max) - left;
+  const isNarrow = width < 3; // less than ~3% of bar
+
+  return (
+    <div ref={barRef} className="relative h-full bg-white/[0.04] rounded overflow-hidden">
+      {/* Gridlines */}
+      <div className="absolute top-0 bottom-0 w-px bg-white/[0.06]" style={{ left: "25%" }} />
+      <div className="absolute top-0 bottom-0 w-px bg-white/[0.08]" style={{ left: "50%" }} />
+      <div className="absolute top-0 bottom-0 w-px bg-white/[0.06]" style={{ left: "75%" }} />
+      {/* Range bar — minWidth ensures narrow ranges are always grabbable */}
+      <div
+        className="absolute top-0.5 bottom-0.5 rounded-sm cursor-grab active:cursor-grabbing"
+        style={{
+          left: `${left}%`,
+          width: `${width}%`,
+          minWidth: 14,
+          backgroundColor: isNarrow ? `${color}88` : `${color}55`,
+          border: isSelected ? `1.5px solid ${color}` : `1px solid ${color}`,
+          boxShadow: isSelected
+            ? `0 0 8px ${color}55`
+            : isNarrow
+              ? `0 0 4px ${color}44`
+              : undefined,
+        }}
+        onPointerDown={(e) => startDrag(e, "move")}
+      >
+        {/* Left resize handle */}
+        <div
+          className="absolute left-0 top-0 bottom-0 w-2 cursor-ew-resize hover:bg-white/20 rounded-l-sm"
+          onPointerDown={(e) => startDrag(e, "min")}
+        />
+        {/* Right resize handle */}
+        <div
+          className="absolute right-0 top-0 bottom-0 w-2 cursor-ew-resize hover:bg-white/20 rounded-r-sm"
+          onPointerDown={(e) => startDrag(e, "max")}
+        />
+      </div>
+    </div>
+  );
 }
 
-function valueToPercent(value: number): number {
-  return ((value + 1) / 2) * 100;
-}
-
-function detectOverlaps(ranges: { Min: number; Max: number; Biome: string }[]): Overlap[] {
-  const overlaps: Overlap[] = [];
-  for (let i = 0; i < ranges.length; i++) {
-    for (let j = i + 1; j < ranges.length; j++) {
-      if (ranges[i].Max > ranges[j].Min && ranges[j].Max > ranges[i].Min) {
-        overlaps.push({
-          i,
-          j,
-          min: Math.max(ranges[i].Min, ranges[j].Min),
-          max: Math.min(ranges[i].Max, ranges[j].Max),
-        });
-      }
-    }
-  }
-  return overlaps;
-}
+// ---------------------------------------------------------------------------
+// Main editor
+// ---------------------------------------------------------------------------
 
 export function BiomeRangeEditor() {
   const biomeRanges = useEditorStore((s) => s.biomeRanges);
@@ -60,225 +182,297 @@ export function BiomeRangeEditor() {
   const removeBiomeRange = useEditorStore((s) => s.removeBiomeRange);
   const commitState = useEditorStore((s) => s.commitState);
   const setDirty = useProjectStore((s) => s.setDirty);
+  const selectedBiomeIndex = useEditorStore((s) => s.selectedBiomeIndex);
+  const setSelectedBiomeIndex = useEditorStore((s) => s.setSelectedBiomeIndex);
+  const renameBiomeRange = useEditorStore((s) => s.renameBiomeRange);
 
-  const containerRef = useRef<HTMLDivElement>(null);
-  const dragRef = useRef<DragState | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [sortKey, setSortKey] = useState<SortKey>("min");
+  const [sortDir, setSortDir] = useState<SortDir>("asc");
+  const [editingName, setEditingName] = useState<{ index: number; value: string } | null>(null);
 
-  const overlaps = useMemo(() => detectOverlaps(biomeRanges), [biomeRanges]);
+  // Original index of drag start values (for committing after drag)
+  const dragOrigRef = useRef<{ index: number; min: number; max: number } | null>(null);
 
-  const pixelToValue = useCallback((pixelX: number): number => {
-    const container = containerRef.current;
-    if (!container) return 0;
-    const rect = container.getBoundingClientRect();
-    const usableWidth = rect.width - AXIS_PADDING * 2;
-    const ratio = (pixelX - rect.left - AXIS_PADDING) / usableWidth;
-    return Math.max(-1, Math.min(1, ratio * 2 - 1));
-  }, []);
+  // Sorted + filtered indices
+  const sortedIndices = useMemo(() => {
+    const indices = biomeRanges.map((_, i) => i);
 
-  const handlePointerDown = useCallback(
-    (e: React.PointerEvent, index: number, type: DragState["type"]) => {
-      e.stopPropagation();
-      (e.target as HTMLElement).setPointerCapture(e.pointerId);
-      dragRef.current = {
-        type,
-        index,
-        startX: e.clientX,
-        originalMin: biomeRanges[index].Min,
-        originalMax: biomeRanges[index].Max,
-      };
-    },
-    [biomeRanges],
-  );
+    // Filter
+    if (searchQuery.trim()) {
+      const q = searchQuery.toLowerCase();
+      const filtered = indices.filter((i) => biomeRanges[i].Biome.toLowerCase().includes(q));
+      return sortList(filtered);
+    }
+    return sortList(indices);
 
-  const handlePointerMove = useCallback(
-    (e: React.PointerEvent) => {
-      const drag = dragRef.current;
-      if (!drag) return;
+    function sortList(list: number[]) {
+      return list.sort((a, b) => {
+        const ra = biomeRanges[a];
+        const rb = biomeRanges[b];
+        let cmp = 0;
+        if (sortKey === "name") cmp = ra.Biome.localeCompare(rb.Biome);
+        else if (sortKey === "min") cmp = ra.Min - rb.Min;
+        else if (sortKey === "max") cmp = ra.Max - rb.Max;
+        else cmp = (ra.Max - ra.Min) - (rb.Max - rb.Min);
+        return sortDir === "asc" ? cmp : -cmp;
+      });
+    }
+  }, [biomeRanges, searchQuery, sortKey, sortDir]);
 
-      const currentValue = pixelToValue(e.clientX);
-      const deltaValue = currentValue - pixelToValue(drag.startX);
-
-      let newMin = drag.originalMin;
-      let newMax = drag.originalMax;
-
-      if (drag.type === "move") {
-        const width = drag.originalMax - drag.originalMin;
-        newMin = drag.originalMin + deltaValue;
-        newMax = drag.originalMax + deltaValue;
-        // Clamp both ends
-        if (newMin < -1) {
-          newMin = -1;
-          newMax = -1 + width;
-        }
-        if (newMax > 1) {
-          newMax = 1;
-          newMin = 1 - width;
-        }
-      } else if (drag.type === "resize-min") {
-        newMin = Math.max(-1, Math.min(drag.originalMax - MIN_GAP, drag.originalMin + deltaValue));
-      } else {
-        newMax = Math.min(1, Math.max(drag.originalMin + MIN_GAP, drag.originalMax + deltaValue));
+  const handleSort = useCallback((key: SortKey) => {
+    setSortKey((prev) => {
+      if (prev === key) {
+        setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+        return prev;
       }
-
-      updateBiomeRange(drag.index, { Min: newMin, Max: newMax });
-    },
-    [pixelToValue, updateBiomeRange],
-  );
-
-  const handlePointerUp = useCallback(
-    (e: React.PointerEvent) => {
-      if (!dragRef.current) return;
-      (e.target as HTMLElement).releasePointerCapture(e.pointerId);
-      dragRef.current = null;
-      commitState("Drag biome range");
-      setDirty(true);
-    },
-    [commitState, setDirty],
-  );
+      setSortDir("asc");
+      return key;
+    });
+  }, []);
 
   const handleAddBiome = useCallback(() => {
     addBiomeRange({ Biome: "new_biome", Min: -0.25, Max: 0.25 });
   }, [addBiomeRange]);
 
   const handleRemove = useCallback(
-    (e: React.MouseEvent, index: number) => {
-      e.stopPropagation();
+    (index: number) => {
       removeBiomeRange(index);
     },
     [removeBiomeRange],
   );
 
-  const ticks = [-1.0, -0.5, 0.0, 0.5, 1.0];
+  const handleSelect = useCallback(
+    (index: number) => {
+      setSelectedBiomeIndex(selectedBiomeIndex === index ? null : index);
+    },
+    [selectedBiomeIndex, setSelectedBiomeIndex],
+  );
+
+  const handleRenameCommit = useCallback(() => {
+    if (editingName) {
+      renameBiomeRange(editingName.index, editingName.value);
+      setEditingName(null);
+    }
+  }, [editingName, renameBiomeRange]);
+
+  // Drag callbacks — store original values on first drag event, commit on pointer up
+  const makeDragHandler = useCallback(
+    (index: number, mode: "min" | "max" | "move") => {
+      return (delta: number) => {
+        const range = biomeRanges[index];
+        if (!dragOrigRef.current || dragOrigRef.current.index !== index) {
+          dragOrigRef.current = { index, min: range.Min, max: range.Max };
+        }
+        const orig = dragOrigRef.current;
+        let newMin = orig.min;
+        let newMax = orig.max;
+
+        if (mode === "move") {
+          const w = orig.max - orig.min;
+          newMin = Math.max(-1, Math.min(1 - w, orig.min + delta));
+          newMax = newMin + w;
+        } else if (mode === "min") {
+          newMin = Math.max(-1, Math.min(orig.max - MIN_GAP, orig.min + delta));
+        } else {
+          newMax = Math.min(1, Math.max(orig.min + MIN_GAP, orig.max + delta));
+        }
+        updateBiomeRange(index, { Min: newMin, Max: newMax });
+      };
+    },
+    [biomeRanges, updateBiomeRange],
+  );
+
+  // Global pointerup to commit drag
+  const handlePointerUp = useCallback(() => {
+    if (dragOrigRef.current) {
+      dragOrigRef.current = null;
+      commitState("Drag biome range");
+      setDirty(true);
+    }
+  }, [commitState, setDirty]);
+
+  const sortIndicator = (key: SortKey) => {
+    if (sortKey !== key) return null;
+    return <span className="ml-0.5 text-tn-accent">{sortDir === "asc" ? "\u25B4" : "\u25BE"}</span>;
+  };
 
   return (
-    <div className="flex flex-col h-full bg-tn-surface border-b border-tn-border">
-      {/* Header */}
-      <div className="flex items-center justify-between px-3 py-1.5 border-b border-tn-border shrink-0">
-        <span className="text-xs font-semibold text-tn-text">Biome Ranges</span>
+    <div className="flex flex-col h-full bg-tn-surface border-b border-tn-border" onPointerUp={handlePointerUp}>
+      {/* Header row */}
+      <div className="flex items-center gap-2 px-3 py-1.5 border-b border-tn-border shrink-0">
+        <span className="text-xs font-semibold text-tn-text shrink-0">Biome Ranges</span>
+        <span className="text-[10px] text-tn-text-muted shrink-0">({biomeRanges.length})</span>
+
+        <input
+          type="text"
+          placeholder="Search..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          className="flex-1 min-w-0 max-w-[180px] h-5 px-1.5 text-[10px] bg-tn-surface-raised border border-tn-border rounded text-tn-text placeholder:text-tn-text-muted/50 focus:outline-none focus:border-tn-accent/50"
+        />
+
         <button
           onClick={handleAddBiome}
-          className="text-[11px] px-2 py-0.5 rounded bg-tn-accent/20 text-tn-accent hover:bg-tn-accent/30 transition-colors"
+          className="text-[10px] px-2 py-0.5 rounded bg-tn-accent/20 text-tn-accent hover:bg-tn-accent/30 transition-colors shrink-0"
         >
-          + Add Biome
+          + Add
         </button>
       </div>
 
-      {/* Axis area */}
-      <div
-        ref={containerRef}
-        className="flex-1 relative mx-3 my-1 select-none"
-        onPointerMove={handlePointerMove}
-        onPointerUp={handlePointerUp}
-      >
-        {/* Tick marks and labels */}
-        <div className="absolute top-0 left-0 right-0 h-4" style={{ marginLeft: AXIS_PADDING, marginRight: AXIS_PADDING }}>
-          {ticks.map((tick) => {
-            const pct = valueToPercent(tick);
+      {/* Coverage overview strip */}
+      <div className="px-3 pt-1.5 pb-1 shrink-0">
+        <CoverageStrip
+          ranges={biomeRanges}
+          selectedIndex={selectedBiomeIndex}
+          onSelect={handleSelect}
+        />
+      </div>
+
+      {/* Column headers */}
+      <div className="flex items-center gap-1 px-3 py-0.5 border-b border-tn-border shrink-0 text-[9px] text-tn-text-muted uppercase tracking-wider">
+        <div className="w-3 shrink-0" />
+        <button
+          className="w-[140px] shrink-0 text-left hover:text-tn-text transition-colors flex items-center"
+          onClick={() => handleSort("name")}
+        >
+          Name{sortIndicator("name")}
+        </button>
+        <div className="flex-1 text-center">Range</div>
+        <button
+          className="w-12 shrink-0 text-right hover:text-tn-text transition-colors flex items-center justify-end"
+          onClick={() => handleSort("min")}
+        >
+          Min{sortIndicator("min")}
+        </button>
+        <button
+          className="w-12 shrink-0 text-right hover:text-tn-text transition-colors flex items-center justify-end"
+          onClick={() => handleSort("max")}
+        >
+          Max{sortIndicator("max")}
+        </button>
+        <button
+          className="w-10 shrink-0 text-right hover:text-tn-text transition-colors flex items-center justify-end"
+          onClick={() => handleSort("width")}
+        >
+          W{sortIndicator("width")}
+        </button>
+        <div className="w-5 shrink-0" />
+      </div>
+
+      {/* Scrollable biome list */}
+      <div className="flex-1 min-h-0 overflow-y-auto">
+        <div style={{ height: sortedIndices.length * ROW_H }}>
+          {sortedIndices.map((origIdx) => {
+            const range = biomeRanges[origIdx];
+            if (!range) return null;
+            const color = biomeColor(range.Biome);
+            const isSel = selectedBiomeIndex === origIdx;
+            const isEditing = editingName?.index === origIdx;
+
             return (
-              <div key={tick} className="absolute" style={{ left: `${pct}%`, transform: "translateX(-50%)" }}>
-                <div className="w-px h-2 bg-tn-text-muted mx-auto" />
-                <span className="text-[9px] text-tn-text-muted">{tick.toFixed(1)}</span>
+              <div
+                key={origIdx}
+                className={`flex items-center gap-1 px-3 border-b border-white/[0.03] cursor-pointer transition-colors ${
+                  isSel ? "bg-tn-accent/[0.08]" : "hover:bg-white/[0.02]"
+                }`}
+                style={{ height: ROW_H }}
+                onClick={() => handleSelect(origIdx)}
+              >
+                {/* Color swatch */}
+                <div
+                  className="w-2.5 h-2.5 rounded-[3px] shrink-0"
+                  style={{ backgroundColor: color }}
+                />
+
+                {/* Name */}
+                <div className="w-[140px] shrink-0 min-w-0">
+                  {isEditing ? (
+                    <input
+                      autoFocus
+                      type="text"
+                      value={editingName.value}
+                      onChange={(e) => setEditingName({ index: origIdx, value: e.target.value })}
+                      onBlur={handleRenameCommit}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") handleRenameCommit();
+                        if (e.key === "Escape") setEditingName(null);
+                      }}
+                      onClick={(e) => e.stopPropagation()}
+                      className="w-full h-5 px-1 text-[10px] bg-tn-surface border border-tn-accent/50 rounded text-tn-text focus:outline-none"
+                    />
+                  ) : (
+                    <span
+                      className="block text-[10px] text-tn-text truncate"
+                      onDoubleClick={(e) => {
+                        e.stopPropagation();
+                        setEditingName({ index: origIdx, value: range.Biome });
+                      }}
+                      title={range.Biome}
+                    >
+                      {range.Biome}
+                    </span>
+                  )}
+                </div>
+
+                {/* Mini range bar */}
+                <div className="flex-1 h-3.5 min-w-0">
+                  <MiniRangeBar
+                    min={range.Min}
+                    max={range.Max}
+                    color={color}
+                    isSelected={isSel}
+                    onDragMin={makeDragHandler(origIdx, "min")}
+                    onDragMax={makeDragHandler(origIdx, "max")}
+                    onDragMove={makeDragHandler(origIdx, "move")}
+                  />
+                </div>
+
+                {/* Min value */}
+                <input
+                  type="number"
+                  step={0.01}
+                  value={range.Min.toFixed(2)}
+                  onChange={(e) => {
+                    const v = parseFloat(e.target.value);
+                    if (!isNaN(v)) updateBiomeRange(origIdx, { Min: Math.max(-1, Math.min(range.Max - MIN_GAP, v)) });
+                  }}
+                  onBlur={() => { commitState("Edit biome min"); setDirty(true); }}
+                  onClick={(e) => e.stopPropagation()}
+                  className="w-12 shrink-0 h-5 px-0.5 text-[10px] text-right bg-transparent border border-transparent hover:border-tn-border focus:border-tn-accent/50 rounded text-tn-text-muted focus:text-tn-text tabular-nums focus:outline-none"
+                />
+
+                {/* Max value */}
+                <input
+                  type="number"
+                  step={0.01}
+                  value={range.Max.toFixed(2)}
+                  onChange={(e) => {
+                    const v = parseFloat(e.target.value);
+                    if (!isNaN(v)) updateBiomeRange(origIdx, { Max: Math.min(1, Math.max(range.Min + MIN_GAP, v)) });
+                  }}
+                  onBlur={() => { commitState("Edit biome max"); setDirty(true); }}
+                  onClick={(e) => e.stopPropagation()}
+                  className="w-12 shrink-0 h-5 px-0.5 text-[10px] text-right bg-transparent border border-transparent hover:border-tn-border focus:border-tn-accent/50 rounded text-tn-text-muted focus:text-tn-text tabular-nums focus:outline-none"
+                />
+
+                {/* Width display */}
+                <span className="w-10 shrink-0 text-[9px] text-tn-text-muted/60 text-right tabular-nums">
+                  {(range.Max - range.Min).toFixed(2)}
+                </span>
+
+                {/* Delete */}
+                <button
+                  className="w-5 shrink-0 h-5 flex items-center justify-center text-[10px] text-tn-text-muted/40 hover:text-red-400 transition-colors rounded"
+                  onClick={(e) => { e.stopPropagation(); handleRemove(origIdx); }}
+                  title="Remove"
+                >
+                  x
+                </button>
               </div>
             );
           })}
         </div>
-
-        {/* Range blocks */}
-        <div
-          className="absolute top-5 left-0 right-0 bottom-4 overflow-y-auto"
-          style={{ marginLeft: AXIS_PADDING, marginRight: AXIS_PADDING }}
-        >
-          <div className="relative" style={{ height: biomeRanges.length * 24 + 8, minHeight: "100%" }}>
-            {biomeRanges.map((range, index) => {
-              const left = valueToPercent(range.Min);
-              const right = valueToPercent(range.Max);
-              const width = right - left;
-              const color = BIOME_COLORS[index % BIOME_COLORS.length];
-
-              return (
-                <div
-                  key={index}
-                  className="absolute flex items-center group"
-                  style={{
-                    left: `${left}%`,
-                    width: `${width}%`,
-                    top: `${index * 24}px`,
-                    height: 20,
-                    minWidth: 16,
-                  }}
-                >
-                  {/* Left handle */}
-                  <div
-                    className="absolute left-0 top-0 bottom-0 cursor-ew-resize z-10 hover:bg-white/20 rounded-l"
-                    style={{ width: HANDLE_WIDTH }}
-                    onPointerDown={(e) => handlePointerDown(e, index, "resize-min")}
-                  />
-
-                  {/* Block body */}
-                  <div
-                    className="absolute inset-0 rounded cursor-grab active:cursor-grabbing flex items-center justify-center overflow-hidden"
-                    style={{ backgroundColor: `${color}33`, border: `1px solid ${color}88` }}
-                    onPointerDown={(e) => handlePointerDown(e, index, "move")}
-                  >
-                    <span
-                      className="text-[10px] font-medium truncate px-2 pointer-events-none"
-                      style={{ color }}
-                    >
-                      {range.Biome}
-                    </span>
-                  </div>
-
-                  {/* Right handle */}
-                  <div
-                    className="absolute right-0 top-0 bottom-0 cursor-ew-resize z-10 hover:bg-white/20 rounded-r"
-                    style={{ width: HANDLE_WIDTH }}
-                    onPointerDown={(e) => handlePointerDown(e, index, "resize-max")}
-                  />
-
-                  {/* Delete button */}
-                  <button
-                    className="absolute -top-1.5 -right-1.5 w-4 h-4 rounded-full bg-red-500/80 text-white text-[9px] leading-none opacity-0 group-hover:opacity-100 transition-opacity z-20 flex items-center justify-center"
-                    onClick={(e) => handleRemove(e, index)}
-                  >
-                    x
-                  </button>
-                </div>
-              );
-            })}
-
-            {/* Overlap overlays */}
-            {overlaps.map((overlap, idx) => {
-              const left = valueToPercent(overlap.min);
-              const right = valueToPercent(overlap.max);
-              const width = right - left;
-              return (
-                <div
-                  key={`overlap-${idx}`}
-                  className="absolute rounded pointer-events-none"
-                  style={{
-                    left: `${left}%`,
-                    width: `${width}%`,
-                    top: 0,
-                    bottom: 0,
-                    backgroundColor: "rgba(239, 68, 68, 0.15)",
-                    border: "1px dashed rgba(239, 68, 68, 0.4)",
-                  }}
-                />
-              );
-            })}
-          </div>
-        </div>
-
-        {/* Overlap warnings */}
-        {overlaps.length > 0 && (
-          <div className="absolute bottom-0 left-0 right-0">
-            {overlaps.map((overlap, idx) => (
-              <span key={idx} className="text-[9px] text-red-400 mr-3">
-                Overlap: {biomeRanges[overlap.i].Biome} & {biomeRanges[overlap.j].Biome} ({overlap.min.toFixed(2)} to {overlap.max.toFixed(2)})
-              </span>
-            ))}
-          </div>
-        )}
       </div>
     </div>
   );

--- a/src/components/editor/CenterPanel.tsx
+++ b/src/components/editor/CenterPanel.tsx
@@ -133,14 +133,16 @@ export function CenterPanel() {
   return <EditorCanvas />;
 }
 
-const BAND_HEIGHT = 24;
-const EDITOR_OVERHEAD = 52; // header (~30px) + tick axis (~16px) + margins (~6px)
-const MIN_EDITOR_H = 80;
-const MAX_EDITOR_H = 300;
+const ROW_H = 28;
+const EDITOR_OVERHEAD = 90; // header + coverage strip + column headers
+const MIN_EDITOR_H = 160;
+const MAX_EDITOR_H = 500;
 
 function defaultEditorHeight(biomeCount: number): number {
   if (biomeCount === 0) return 160;
-  return Math.max(MIN_EDITOR_H, Math.min(MAX_EDITOR_H, biomeCount * BAND_HEIGHT + EDITOR_OVERHEAD));
+  // Show ~8–12 rows by default, capped
+  const visibleRows = Math.min(biomeCount, 12);
+  return Math.max(MIN_EDITOR_H, Math.min(MAX_EDITOR_H, visibleRows * ROW_H + EDITOR_OVERHEAD));
 }
 
 /** NoiseRange layout with floating view mode overlay */

--- a/src/components/editor/RootDock.tsx
+++ b/src/components/editor/RootDock.tsx
@@ -5,12 +5,19 @@ import { useLanguage } from "@/languages/useLanguage";
 
 const ROOT_COLOR = "#8B4450";
 
+/** Editing contexts where the Root dock is irrelevant (no density root node). */
+const HIDDEN_CONTEXTS = new Set(["NoiseRange", "Settings", "RawJson"]);
+
 export function RootDock() {
   const [collapsed, setCollapsed] = useState(false);
   const nodes = useEditorStore((s) => s.nodes);
   const edges = useEditorStore((s) => s.edges);
+  const editingContext = useEditorStore((s) => s.editingContext);
   const { getTypeDisplayName } = useLanguage();
   const reactFlow = useReactFlow();
+
+  // Hide for non-graph editing contexts (world structure, settings, raw JSON)
+  if (editingContext && HIDDEN_CONTEXTS.has(editingContext)) return null;
 
   // Find the Root node in the graph
   const rootNode = nodes.find((n) => n.type === "Root");

--- a/src/components/editor/__tests__/BiomeRangeEditor.test.tsx
+++ b/src/components/editor/__tests__/BiomeRangeEditor.test.tsx
@@ -11,10 +11,10 @@ describe("BiomeRangeEditor", () => {
   it("renders the header and add button", () => {
     render(<BiomeRangeEditor />);
     expect(screen.getByText("Biome Ranges")).toBeTruthy();
-    expect(screen.getByText("+ Add Biome")).toBeTruthy();
+    expect(screen.getByText("+ Add")).toBeTruthy();
   });
 
-  it("renders correct number of range blocks from store state", () => {
+  it("renders biome names in the list from store state", () => {
     useEditorStore.getState().setBiomeRanges([
       { Biome: "forest_hills", Min: -1.0, Max: 1.0 },
       { Biome: "desert", Min: -0.5, Max: 0.5 },
@@ -25,27 +25,31 @@ describe("BiomeRangeEditor", () => {
     expect(screen.getByText("desert")).toBeTruthy();
   });
 
-  it("detects overlapping ranges and shows warning", () => {
+  it("displays biome count in the header", () => {
     useEditorStore.getState().setBiomeRanges([
       { Biome: "forest_hills", Min: -0.5, Max: 0.5 },
       { Biome: "desert", Min: 0.1, Max: 0.8 },
     ]);
 
     render(<BiomeRangeEditor />);
-    expect(screen.getByText(/Overlap.*forest_hills.*desert/)).toBeTruthy();
+    expect(screen.getByText("(2)")).toBeTruthy();
   });
 
-  it("does not show overlap warning for non-overlapping ranges", () => {
+  it("filters biomes by search query", () => {
     useEditorStore.getState().setBiomeRanges([
       { Biome: "forest_hills", Min: -1.0, Max: 0.0 },
       { Biome: "desert", Min: 0.0, Max: 1.0 },
     ]);
 
     render(<BiomeRangeEditor />);
-    expect(screen.queryByText(/Overlap/)).toBeNull();
+    const searchInput = screen.getByPlaceholderText("Search...");
+    fireEvent.change(searchInput, { target: { value: "forest" } });
+
+    expect(screen.getByText("forest_hills")).toBeTruthy();
+    expect(screen.queryByText("desert")).toBeNull();
   });
 
-  it("adding a biome range increases block count", () => {
+  it("adding a biome range increases list count", () => {
     useEditorStore.getState().setBiomeRanges([
       { Biome: "forest_hills", Min: -1.0, Max: 1.0 },
     ]);
@@ -53,13 +57,13 @@ describe("BiomeRangeEditor", () => {
     render(<BiomeRangeEditor />);
     expect(screen.getByText("forest_hills")).toBeTruthy();
 
-    fireEvent.click(screen.getByText("+ Add Biome"));
+    fireEvent.click(screen.getByText("+ Add"));
 
     expect(screen.getByText("new_biome")).toBeTruthy();
     expect(useEditorStore.getState().biomeRanges).toHaveLength(2);
   });
 
-  it("removing a biome range decreases block count", () => {
+  it("removing a biome range decreases list count", () => {
     useEditorStore.getState().setBiomeRanges([
       { Biome: "forest_hills", Min: -1.0, Max: 1.0 },
       { Biome: "desert", Min: -0.5, Max: 0.5 },
@@ -88,5 +92,24 @@ describe("BiomeRangeEditor", () => {
     useEditorStore.getState().setBiomeRanges([]);
     render(<BiomeRangeEditor />);
     expect(screen.getByText("Biome Ranges")).toBeTruthy();
+  });
+
+  it("shows column headers for sorting", () => {
+    render(<BiomeRangeEditor />);
+    expect(screen.getByText("Name")).toBeTruthy();
+    expect(screen.getByText("Range")).toBeTruthy();
+    expect(screen.getByText("Min")).toBeTruthy();
+    expect(screen.getByText("Max")).toBeTruthy();
+  });
+
+  it("selects a biome on click", () => {
+    useEditorStore.getState().setBiomeRanges([
+      { Biome: "forest_hills", Min: -1.0, Max: 0.0 },
+      { Biome: "desert", Min: 0.0, Max: 1.0 },
+    ]);
+
+    render(<BiomeRangeEditor />);
+    fireEvent.click(screen.getByText("forest_hills"));
+    expect(useEditorStore.getState().selectedBiomeIndex).toBe(0);
   });
 });

--- a/src/nodes/density/NoiseNodes.tsx
+++ b/src/nodes/density/NoiseNodes.tsx
@@ -6,6 +6,15 @@ import { safeDisplay } from "@/nodes/shared/displayUtils";
 
 const OUTPUT_ONLY_HANDLES = [densityOutput()];
 
+/** Resolve internal field name with Hytale fallback for noise nodes */
+function resolveNoiseField(fields: Record<string, any>, name: string): unknown {
+  if (fields[name] != null) return fields[name];
+  // Fallback: handle Hytale field names that weren't translated
+  if (name === "Frequency" && fields.Scale != null) return 1 / (fields.Scale as number);
+  if (name === "Gain" && fields.Persistence != null) return fields.Persistence;
+  return undefined;
+}
+
 function NoiseNodeBody({ data, fields }: { data: { fields: Record<string, any> }; fields: string[] }) {
   const labels: Record<string, string> = {
     Frequency: "Freq",
@@ -20,7 +29,7 @@ function NoiseNodeBody({ data, fields }: { data: { fields: Record<string, any> }
       {fields.map((f) => (
         <div key={f} className="flex justify-between">
           <span className="text-tn-text-muted">{labels[f] ?? f}</span>
-          <span>{safeDisplay(data.fields[f])}</span>
+          <span>{safeDisplay(resolveNoiseField(data.fields, f))}</span>
         </div>
       ))}
     </div>

--- a/src/nodes/density/SimplexNoise2DNode.tsx
+++ b/src/nodes/density/SimplexNoise2DNode.tsx
@@ -9,16 +9,20 @@ const SIMPLEX_NOISE_2D_HANDLES = [densityOutput()];
 export const SimplexNoise2DNode = memo(function SimplexNoise2DNode(props: TypedNodeProps) {
   const data = props.data;
 
+  // Handle both internal (Frequency) and Hytale (Scale) field names
+  const freq = data.fields.Frequency ?? (data.fields.Scale != null ? 1 / (data.fields.Scale as number) : 0.01);
+  const amp = data.fields.Amplitude ?? data.fields.Persistence ?? 1.0;
+
   return (
     <BaseNode {...props} category={AssetCategory.Density} handles={SIMPLEX_NOISE_2D_HANDLES}>
       <div className="space-y-1">
         <div className="flex justify-between">
           <span className="text-tn-text-muted">Freq</span>
-          <span>{safeDisplay(data.fields.Frequency, 0.01)}</span>
+          <span>{safeDisplay(freq, 0.01)}</span>
         </div>
         <div className="flex justify-between">
           <span className="text-tn-text-muted">Amp</span>
-          <span>{safeDisplay(data.fields.Amplitude, 1.0)}</span>
+          <span>{safeDisplay(amp, 1.0)}</span>
         </div>
         <div className="flex justify-between">
           <span className="text-tn-text-muted">Seed</span>

--- a/src/stores/slices/biomeRangesSlice.ts
+++ b/src/stores/slices/biomeRangesSlice.ts
@@ -14,6 +14,7 @@ import type {
 export const biomeRangesInitialState = {
   biomeRanges: [] as BiomeRangeEntry[],
   noiseRangeConfig: null as NoiseRangeConfig | null,
+  selectedBiomeIndex: null as number | null,
 };
 
 // ---------------------------------------------------------------------------
@@ -51,7 +52,20 @@ export const createBiomeRangesSlice: SliceCreator<BiomeRangesSliceState> = (set)
       const mutateAndCommit = getMutateAndCommit();
       mutateAndCommit((state) => ({
         biomeRanges: state.biomeRanges.filter((_, i) => i !== index),
+        selectedBiomeIndex: state.selectedBiomeIndex === index ? null : state.selectedBiomeIndex,
       }), "Remove biome range");
+      markDirty();
+    },
+
+    setSelectedBiomeIndex: (index) => set({ selectedBiomeIndex: index }),
+
+    renameBiomeRange: (index, name) => {
+      const mutateAndCommit = getMutateAndCommit();
+      mutateAndCommit((state) => {
+        const ranges = [...state.biomeRanges];
+        ranges[index] = { ...ranges[index], Biome: name };
+        return { biomeRanges: ranges };
+      }, "Rename biome range");
       markDirty();
     },
   };

--- a/src/stores/slices/types.ts
+++ b/src/stores/slices/types.ts
@@ -139,12 +139,15 @@ export interface BiomeSectionsSliceState {
 export interface BiomeRangesSliceState {
   biomeRanges: BiomeRangeEntry[];
   noiseRangeConfig: NoiseRangeConfig | null;
+  selectedBiomeIndex: number | null;
 
   setBiomeRanges: (ranges: BiomeRangeEntry[]) => void;
   setNoiseRangeConfig: (config: NoiseRangeConfig | null) => void;
   updateBiomeRange: (index: number, entry: Partial<BiomeRangeEntry>) => void;
   addBiomeRange: (entry: BiomeRangeEntry) => void;
   removeBiomeRange: (index: number) => void;
+  setSelectedBiomeIndex: (index: number | null) => void;
+  renameBiomeRange: (index: number, name: string) => void;
 }
 
 export interface FileCacheSliceState {


### PR DESCRIPTION
## Summary

- **SimplexNoise2D settings not taking effect**: Files without `$NodeId` bypassed the Hytale→Internal field name translation, causing Hytale field names (Scale, Persistence) to be stored raw. Added content-based detection of Hytale field names in `normalizeImport` so translation triggers regardless of `$NodeId` presence. Added safety fallback reads in noise node components.

- **BiomeRangeEditor unusable with 80-150+ biomes**: Redesigned from stacked absolute-positioned blocks (diagonal staircase of tiny dots) to a list-based editor with coverage overview strip, sortable columns, search filter, draggable inline range bars with 14px minimum width, deterministic per-biome colors, inline rename, and precise min/max number inputs.

- **RootDock "No Root" overlay on world structure files**: Hidden for NoiseRange, Settings, and RawJson editing contexts where it's irrelevant.

## Changes

| File | What |
|------|------|
| `fileTypeDetection.ts` | Add `hasHytaleFieldNames()` recursive detector, update `normalizeImport` |
| `SimplexNoise2DNode.tsx` | Fallback field reads (Frequency←Scale, Amplitude←Persistence) |
| `NoiseNodes.tsx` | `resolveNoiseField()` helper with Hytale fallbacks for all noise types |
| `BiomeRangeEditor.tsx` | Full redesign: list layout, coverage strip, sort, search, drag, rename |
| `biomeRangesSlice.ts` | Add `selectedBiomeIndex`, `renameBiomeRange` state/actions |
| `types.ts` | Add `selectedBiomeIndex`, `setSelectedBiomeIndex`, `renameBiomeRange` to interface |
| `CenterPanel.tsx` | Update height calculation for new list-based editor |
| `RootDock.tsx` | Hide on NoiseRange/Settings/RawJson contexts |
| `BiomeRangeEditor.test.tsx` | Updated tests for new list layout + added search/sort/selection tests |

## Test plan

- [x] `npx vitest run` — 117 relevant tests pass (107 translation + 10 biome editor)
- [x] TypeScript compiles cleanly
- [ ] Open a biome file without `$NodeId` → verify SimplexNoise2D shows correct values
- [ ] Open `Combined_Generation_V1.json` (151 biomes) → verify list renders cleanly
- [ ] Test search, sort columns, drag range bars, edit min/max inputs
- [ ] Verify "No Root" does not appear on world structure files