### PR TITLE
feat: knife tool for cutting wires

### DIFF
--- a/src/components/editor/KnifeOverlay.tsx
+++ b/src/components/editor/KnifeOverlay.tsx
@@ -1,0 +1,32 @@
+import type { KnifeOverlayProps } from "@/hooks/useKnifeTool";
+
+export function KnifeOverlay({ active, points }: KnifeOverlayProps) {
+  if (!active || points.length < 2) return null;
+
+  const polylineStr = points.map((p) => `${p.x},${p.y}`).join(" ");
+
+  return (
+    <svg className="knife-overlay">
+      {/* Glow layer */}
+      <polyline
+        points={polylineStr}
+        fill="none"
+        stroke="#ff4444"
+        strokeWidth={4}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        opacity={0.3}
+      />
+      {/* Main line */}
+      <polyline
+        points={polylineStr}
+        fill="none"
+        stroke="#ff4444"
+        strokeWidth={2}
+        strokeDasharray="6 4"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/src/hooks/useKnifeTool.ts
+++ b/src/hooks/useKnifeTool.ts
@@ -1,0 +1,187 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useReactFlow } from "@xyflow/react";
+import { useEditorStore } from "@/stores/editorStore";
+import { sampleAllEdgePaths } from "@/utils/graphGeometry";
+import { polylinesIntersect, type Point } from "@/utils/lineIntersection";
+
+interface UseKnifeToolOptions {
+  containerRef: React.RefObject<HTMLDivElement | null>;
+}
+
+export interface KnifeOverlayProps {
+  active: boolean;
+  points: Point[];
+}
+
+export function useKnifeTool({ containerRef }: UseKnifeToolOptions) {
+  const [knifeActive, setKnifeActive] = useState(false);
+  const [cutEdgeIds, setCutEdgeIds] = useState<Set<string>>(new Set());
+  const [overlayPoints, setOverlayPoints] = useState<Point[]>([]);
+  const reactFlowInstance = useReactFlow();
+
+  // Suppress native context menu when knife modifier keys are held (Ctrl+Shift)
+  // Tauri/WebView interprets Ctrl+Shift+click as a context menu trigger
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const suppress = (e: MouseEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.shiftKey) {
+        e.preventDefault();
+      }
+    };
+    el.addEventListener("contextmenu", suppress, { capture: true });
+    return () => el.removeEventListener("contextmenu", suppress, { capture: true });
+  }, [containerRef]);
+
+  // Refs for drag state (avoid re-renders during rapid mouse moves)
+  const knifeScreenPointsRef = useRef<Point[]>([]);
+  const knifeFlowPointsRef = useRef<Point[]>([]);
+  const cachedEdgePathsRef = useRef<Map<string, Point[]>>(new Map());
+  const rafIdRef = useRef<number | null>(null);
+  const activeRef = useRef(false);
+  const pointerIdRef = useRef<number | null>(null);
+
+  const testIntersections = useCallback(() => {
+    const knifeLine = knifeFlowPointsRef.current;
+    if (knifeLine.length < 2) return;
+
+    const intersected = new Set<string>();
+    for (const [edgeId, edgePath] of cachedEdgePathsRef.current) {
+      if (polylinesIntersect(knifeLine, edgePath)) {
+        intersected.add(edgeId);
+      }
+    }
+    setCutEdgeIds(intersected);
+  }, []);
+
+  // Use capture phase so we intercept before ReactFlow starts marquee/pan
+  const handlePointerDownCapture = useCallback(
+    (e: React.PointerEvent) => {
+      // Activate on LMB + (Ctrl or Meta) + Shift
+      if (
+        e.button !== 0 ||
+        !(e.ctrlKey || e.metaKey) ||
+        !e.shiftKey
+      ) {
+        return;
+      }
+
+      e.stopPropagation();
+      e.preventDefault();
+      // Also stop native propagation to prevent ReactFlow from seeing it
+      e.nativeEvent.stopImmediatePropagation();
+
+      // Cache edge paths in flow-space at drag start
+      const container = containerRef.current;
+      if (container) {
+        cachedEdgePathsRef.current = sampleAllEdgePaths(container);
+      }
+
+      // Convert screen position to flow-space
+      const screenPt: Point = { x: e.clientX, y: e.clientY };
+      const flowPt = reactFlowInstance.screenToFlowPosition(screenPt);
+
+      knifeScreenPointsRef.current = [screenPt];
+      knifeFlowPointsRef.current = [flowPt];
+      activeRef.current = true;
+      pointerIdRef.current = e.pointerId;
+      setKnifeActive(true);
+      setOverlayPoints([screenPt]);
+      setCutEdgeIds(new Set());
+
+      // Capture pointer on the container so events are consistently delivered
+      containerRef.current?.setPointerCapture(e.pointerId);
+    },
+    [containerRef, reactFlowInstance],
+  );
+
+  const handlePointerMoveCapture = useCallback(
+    (e: React.PointerEvent) => {
+      if (!activeRef.current) return;
+
+      e.stopPropagation();
+      e.preventDefault();
+      e.nativeEvent.stopImmediatePropagation();
+
+      const screenPt: Point = { x: e.clientX, y: e.clientY };
+      const flowPt = reactFlowInstance.screenToFlowPosition(screenPt);
+
+      knifeScreenPointsRef.current.push(screenPt);
+      knifeFlowPointsRef.current.push(flowPt);
+      setOverlayPoints([...knifeScreenPointsRef.current]);
+
+      // Throttle intersection testing to animation frames
+      if (rafIdRef.current === null) {
+        rafIdRef.current = requestAnimationFrame(() => {
+          rafIdRef.current = null;
+          testIntersections();
+        });
+      }
+    },
+    [testIntersections, reactFlowInstance],
+  );
+
+  const handlePointerUpCapture = useCallback(
+    (e: React.PointerEvent) => {
+      if (!activeRef.current) return;
+
+      e.stopPropagation();
+      e.preventDefault();
+      e.nativeEvent.stopImmediatePropagation();
+
+      activeRef.current = false;
+
+      // Cancel any pending RAF
+      if (rafIdRef.current !== null) {
+        cancelAnimationFrame(rafIdRef.current);
+        rafIdRef.current = null;
+      }
+
+      // Final intersection test with all points
+      const knifeLine = knifeFlowPointsRef.current;
+      const finalCut = new Set<string>();
+      if (knifeLine.length >= 2) {
+        for (const [edgeId, edgePath] of cachedEdgePathsRef.current) {
+          if (polylinesIntersect(knifeLine, edgePath)) {
+            finalCut.add(edgeId);
+          }
+        }
+      }
+
+      // Delete intersected edges in a single history transaction
+      if (finalCut.size > 0) {
+        const ids = Array.from(finalCut);
+        const label = ids.length === 1 ? "Cut edge" : `Cut ${ids.length} edges`;
+        useEditorStore.getState().removeEdges(ids, label);
+      }
+
+      // Reset state
+      setKnifeActive(false);
+      setCutEdgeIds(new Set());
+      setOverlayPoints([]);
+      knifeScreenPointsRef.current = [];
+      knifeFlowPointsRef.current = [];
+      cachedEdgePathsRef.current.clear();
+
+      // Release pointer capture
+      if (pointerIdRef.current !== null) {
+        try {
+          containerRef.current?.releasePointerCapture(pointerIdRef.current);
+        } catch {
+          // pointer capture may already be released
+        }
+        pointerIdRef.current = null;
+      }
+    },
+    [containerRef, testIntersections],
+  );
+
+  return {
+    knifeActive,
+    cutEdgeIds,
+    overlayProps: { active: knifeActive, points: overlayPoints } as KnifeOverlayProps,
+    handlePointerDownCapture,
+    handlePointerMoveCapture,
+    handlePointerUpCapture,
+  };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -85,3 +85,20 @@ body,
   background: transparent !important;
   border: none !important;
 }
+
+/* Knife tool overlay */
+.knife-overlay {
+  position: fixed;
+  inset: 0;
+  width: 100vw;
+  height: 100vh;
+  pointer-events: none;
+  z-index: 9999;
+}
+
+/* Knife tool cut-edge highlight */
+.react-flow__edge.knife-cut-edge .react-flow__edge-path {
+  stroke: #ff4444 !important;
+  stroke-width: 3 !important;
+  filter: drop-shadow(0 0 4px rgba(255, 68, 68, 0.6));
+}

--- a/src/stores/slices/types.ts
+++ b/src/stores/slices/types.ts
@@ -105,6 +105,8 @@ export interface GraphSliceState {
   createGroup: (nodeIds: string[], name: string) => void;
   expandGroup: (groupId: string) => void;
 
+  removeEdges: (ids: string[], label?: string) => void;
+
   // Material layer stack actions
   reorderMaterialLayers: (sadNodeId: string, fromIndex: number, toIndex: number) => void;
   addMaterialLayer: (sadNodeId: string, layerType: string) => void;

--- a/src/utils/lineIntersection.ts
+++ b/src/utils/lineIntersection.ts
@@ -1,0 +1,42 @@
+export interface Point {
+  x: number;
+  y: number;
+}
+
+/**
+ * Test whether two line segments (p1-p2) and (p3-p4) intersect.
+ * Uses cross-product orientation test.
+ */
+export function segmentsIntersect(
+  p1: Point,
+  p2: Point,
+  p3: Point,
+  p4: Point,
+): boolean {
+  const d1x = p2.x - p1.x;
+  const d1y = p2.y - p1.y;
+  const d2x = p4.x - p3.x;
+  const d2y = p4.y - p3.y;
+
+  const denom = d1x * d2y - d1y * d2x;
+  if (Math.abs(denom) < 1e-10) return false; // parallel
+
+  const t = ((p3.x - p1.x) * d2y - (p3.y - p1.y) * d2x) / denom;
+  const u = ((p3.x - p1.x) * d1y - (p3.y - p1.y) * d1x) / denom;
+
+  return t >= 0 && t <= 1 && u >= 0 && u <= 1;
+}
+
+/**
+ * Test whether any segment pair between two polylines intersects.
+ */
+export function polylinesIntersect(lineA: Point[], lineB: Point[]): boolean {
+  for (let i = 0; i < lineA.length - 1; i++) {
+    for (let j = 0; j < lineB.length - 1; j++) {
+      if (segmentsIntersect(lineA[i], lineA[i + 1], lineB[j], lineB[j + 1])) {
+        return true;
+      }
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
## Summary

- Adds a **knife tool** activated via `Ctrl+Shift+LMB` drag (or `Cmd+Shift` on macOS) that lets users slice through one or multiple wires in a single gesture, matching standard node editor UX (Blender, Unreal, etc.)
- Intersected wires highlight red during the drag and are deleted on mouse release
- All cut wires are removed in a **single undo point** with a descriptive history label ("Cut edge" / "Cut N edges")

### New files
| File | Purpose |
|------|---------|
| `src/utils/lineIntersection.ts` | Pure geometry: segment & polyline intersection tests |
| `src/hooks/useKnifeTool.ts` | Core hook: capture-phase pointer events, edge path sampling, flow-space intersection, deletion |
| `src/components/editor/KnifeOverlay.tsx` | Dashed red SVG cut line overlay with glow |

### Modified files
| File | Change |
|------|--------|
| `src/utils/graphGeometry.ts` | Added `sampleAllEdgePaths()` — queries edge DOM, samples path geometry via `getPointAtLength()` |
| `src/stores/slices/graphSlice.ts` | Added `removeEdges()` — single-transaction edge removal with Root node cleanup |
| `src/stores/slices/types.ts` | Added `removeEdges` to `GraphSliceState` interface |
| `src/index.css` | Knife overlay + cut-edge highlight CSS |

## Test plan

- [ ] Open a graph with several connected nodes
- [ ] Hold `Ctrl+Shift`, click and drag across wires — verify red dashed cut line appears and intersected wires highlight red
- [ ] Release mouse — verify wires are deleted
- [ ] `Ctrl+Z` — verify all cut wires restore in a single undo step
- [ ] Verify history panel shows "Cut N edges" entry
- [ ] Verify plain Shift+drag still does marquee selection
- [ ] Verify node dragging and connection dragging still work
- [ ] Test at various zoom levels (zoomed way in and way out)
- [ ] Test cutting a Root node's edge — verify output node clears properly

Closes #13