### PR TITLE
fix: make RangeDouble fields editable in property panel

### DIFF
--- a/src/components/properties/PropertyPanel.tsx
+++ b/src/components/properties/PropertyPanel.tsx
@@ -5,6 +5,7 @@ import { useUIStore } from "@/stores/uiStore";
 import { useFieldChange } from "@/hooks/useFieldChange";
 import { SliderField } from "./SliderField";
 import { VectorField } from "./VectorField";
+import { RangeField } from "./RangeField";
 import { ToggleField } from "./ToggleField";
 import { TextField } from "./TextField";
 import { ArrayField } from "./ArrayField";
@@ -375,6 +376,25 @@ export function PropertyPanel() {
           return (
             <FieldWrapper key={key} issue={issue} helpMode={helpMode} onHelpClick={handleHelpClick} extendedDesc={isExpanded ? extendedDesc : undefined}>
               <VectorField
+                label={fieldLabel}
+                value={v}
+                description={description}
+                onChange={(v) => handleContinuousChange(key, v)}
+                onBlur={handleBlur}
+              />
+            </FieldWrapper>
+          );
+        }
+        if (
+          typeof value === "object" &&
+          value !== null &&
+          "Min" in (value as Record<string, unknown>) &&
+          "Max" in (value as Record<string, unknown>)
+        ) {
+          const v = value as { Min: number; Max: number };
+          return (
+            <FieldWrapper key={key} issue={issue} helpMode={helpMode} onHelpClick={handleHelpClick} extendedDesc={isExpanded ? extendedDesc : undefined}>
+              <RangeField
                 label={fieldLabel}
                 value={v}
                 description={description}

--- a/src/components/properties/RangeField.tsx
+++ b/src/components/properties/RangeField.tsx
@@ -1,0 +1,36 @@
+import { FieldTooltip } from "./FieldTooltip";
+
+interface RangeFieldProps {
+  label: string;
+  value: { Min: number; Max: number };
+  description?: string;
+  onChange: (value: { Min: number; Max: number }) => void;
+  onBlur?: () => void;
+}
+
+export function RangeField({ label, value, description, onChange, onBlur }: RangeFieldProps) {
+  return (
+    <div className="flex flex-col gap-1">
+      <label className="text-xs text-tn-text-muted flex items-center">
+        {label}
+        {description && <FieldTooltip description={description} />}
+      </label>
+      <div className="flex gap-1">
+        {(["Min", "Max"] as const).map((bound) => (
+          <div key={bound} className="flex-1">
+            <label className="text-[10px] text-tn-text-muted uppercase">{bound}</label>
+            <input
+              type="number"
+              value={value[bound]}
+              onChange={(e) =>
+                onChange({ ...value, [bound]: parseFloat(e.target.value) || 0 })
+              }
+              onBlur={onBlur}
+              className="w-full px-1.5 py-0.5 text-xs bg-tn-bg border border-tn-border rounded"
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- RangeDouble fields (SourceRange, TargetRange, etc.) now render as editable Min/Max number inputs instead of read-only JSON text
- Adds `RangeField` component and detection branch in `PropertyPanel`
- Affects Normalizer, DoubleNormalizer, LinearRemap, HeightGradient, and all other nodes with RangeDouble fields

Closes #23