### PR TITLE
fix: add missing Vector input port to Angle density node

### DIFF
--- a/src/nodes/density/PositionNodes.tsx
+++ b/src/nodes/density/PositionNodes.tsx
@@ -103,9 +103,15 @@ export const HeightAboveSurfaceNode = memo(function HeightAboveSurfaceNode(props
   );
 });
 
+const ANGLE_HANDLES = [
+  vectorInput("VectorProvider", "VectorProvider"),
+  vectorInput("Vector", "Vector"),
+  densityOutput(),
+];
+
 export const AngleNode = memo(function AngleNode(props: TypedNodeProps) {
   return (
-    <BaseNode {...props} category={AssetCategory.Density} handles={VECTOR_INPUT_HANDLES}>
+    <BaseNode {...props} category={AssetCategory.Density} handles={ANGLE_HANDLES}>
       <div className="text-tn-text-muted text-center py-1">Angle (deg)</div>
     </BaseNode>
   );

--- a/src/nodes/handleRegistry.ts
+++ b/src/nodes/handleRegistry.ts
@@ -159,7 +159,7 @@ export const HANDLE_REGISTRY: Record<string, HandleDef[]> = {
   Shell: [curveInput("AngleCurve", "Angle Curve"), curveInput("DistanceCurve", "Distance Curve"), densityOutput()],
   Cube: [curveInput("Curve", "Curve"), densityOutput()],
   Axis: [curveInput("Curve", "Curve"), densityOutput()],
-  Angle: [vectorInput("VectorProvider", "Vector"), densityOutput()],
+  Angle: [vectorInput("VectorProvider", "VectorProvider"), vectorInput("Vector", "Vector"), densityOutput()],
   Cache2D: [densityInput("Input", "Input"), densityOutput()],
   OffsetConstant: [densityInput("Input", "Input"), densityOutput()],
   Exported: [densityInput("Input", "Input"), densityOutput()],

--- a/src/schema/defaults.ts
+++ b/src/schema/defaults.ts
@@ -132,7 +132,7 @@ export const DENSITY_DEFAULTS: Record<DensityType, DefaultFields> = {
   OffsetConstant: { Value: 0.0 },
   Cache2D: {},
   Exported: { Name: "", SingleInstance: false },
-  Angle: {},
+  Angle: { Vector: { x: 0, y: 1, z: 0 }, IsAxis: false },
   // Shape SDFs
   Cube: {},
   Axis: { Axis: { x: 0, y: 1, z: 0 }, IsAnchored: false },

--- a/src/schema/fieldDescriptions.ts
+++ b/src/schema/fieldDescriptions.ts
@@ -577,6 +577,11 @@ export const FIELD_DESCRIPTIONS: Record<string, Record<string, string | FieldDes
   OffsetConstant: {
     Value: "Constant offset added to the input. Output = Input + Value. Use to shift a density signal by a fixed amount.",
   },
+  Angle: {
+    Vector: "Static reference vector {x, y, z} for angle computation.",
+    VectorProvider: "Optional dynamic vector provider that overrides the static Vector.",
+    IsAxis: "Whether the reference is treated as an axis (angle measured in 0-180 range).",
+  },
   Axis: {
     Axis: "Unit direction vector {x, y, z} defining the axis of the SDF. Default (0, 1, 0) creates a vertical axis.",
     IsAnchored: "When true, the axis is anchored at the origin. When false, the axis extends infinitely in both directions.",

--- a/src/utils/internalToHytale.ts
+++ b/src/utils/internalToHytale.ts
@@ -1414,7 +1414,7 @@ export function transformNode(asset: V2Asset, ctx: TransformContext = {}): Recor
     }
 
     // NewYAxis plain vector → Point3D format
-    if (key === "NewYAxis" && value && typeof value === "object" && !Array.isArray(value) &&
+    if ((key === "NewYAxis" || key === "Vector") && value && typeof value === "object" && !Array.isArray(value) &&
         "x" in (value as Record<string, unknown>) && !("Type" in (value as Record<string, unknown>))) {
       const vec = value as { x: number; y: number; z: number };
       output[key] = {

--- a/src/utils/translationMaps.ts
+++ b/src/utils/translationMaps.ts
@@ -234,6 +234,7 @@ export const FIELD_TO_CATEGORY: Record<string, string> = {
   Top: "assignment",
   Bottom: "assignment",
   VectorProvider: "vector",
+  Vector: "vector",
   NewYAxis: "vector",
   Queue: "material",
   Layers: "sadLayer",


### PR DESCRIPTION
## Summary

- Adds the missing static `Vector` input port to the Angle density node alongside the existing `VectorProvider` port
- Renames the VectorProvider port label from "Vector" to "VectorProvider" to avoid confusion
- Sets meaningful defaults (`Vector: {x:0, y:1, z:0}`, `IsAxis: false`) instead of empty `{}`
- Adds `Vector` to `FIELD_TO_CATEGORY` so child Constant nodes export with the correct vector category
- Extends the plain vector → Point3D export handler to cover the `Vector` field
- Adds field descriptions for Angle node (Vector, VectorProvider, IsAxis)

Closes #28

## Test plan

- [ ] Build passes (`npm run build`) with no TypeScript errors
- [ ] Existing round-trip tests pass (`npm test`)
- [ ] Create an Angle node from palette → verify it shows "VectorProvider" and "Vector" input ports + density output
- [ ] Import a Hytale JSON with an Angle density that has VectorProvider connected → verify the connection appears on the "VectorProvider" port
- [ ] Export a graph with an Angle node → verify the JSON contains proper `VectorProvider` (Point3D) and optionally `Vector` (Point3D) fields