### PR TITLE
fix: import Manual curves correctly for PositionsCellNoise

### DIFF
--- a/src/nodes/handleRegistry.ts
+++ b/src/nodes/handleRegistry.ts
@@ -130,7 +130,7 @@ export const HANDLE_REGISTRY: Record<string, HandleDef[]> = {
   BaseHeight: [densityOutput()],
   Offset: [densityInput("Input", "Input"), densityInput("Offset", "Offset"), densityOutput()],
   Distance: [curveInput("Curve", "Curve"), densityOutput()],
-  PositionsCellNoise: [densityOutput()],
+  PositionsCellNoise: [curveInput("ReturnCurve", "Return Curve"), densityOutput()],
 
   // Additional density types
   XOverride: [densityInput("Input", "Input"), densityOutput()],

--- a/src/utils/hytaleToInternal.ts
+++ b/src/utils/hytaleToInternal.ts
@@ -933,6 +933,12 @@ function transformNodeToInternal(
         processedFields.ReturnCurve = rt.Curve;
       }
     }
+    // Normalize: when ReturnType is the string "Curve" with a top-level Curve field,
+    // rename Curve → ReturnCurve so both Hytale format variants use the same field name.
+    if (processedFields.ReturnType === "Curve" && processedFields.Curve) {
+      processedFields.ReturnCurve = processedFields.Curve;
+      delete processedFields.Curve;
+    }
     if (processedFields.DistanceFunction && typeof processedFields.DistanceFunction === "object") {
       const df = processedFields.DistanceFunction as Record<string, unknown>;
       processedFields.DistanceFunction = (df.Type as string) ?? "Euclidean";

--- a/src/utils/internalToHytale.ts
+++ b/src/utils/internalToHytale.ts
@@ -1316,6 +1316,12 @@ export function transformNode(asset: V2Asset, ctx: TransformContext = {}): Recor
     transformedFields = transformDensityBasedFields(transformedFields);
   }
 
+  // PositionsCellNoise: ReturnCurve → Curve (reverse of import normalization)
+  if (internalType === "PositionsCellNoise" && "ReturnCurve" in transformedFields) {
+    transformedFields.Curve = transformedFields.ReturnCurve;
+    delete transformedFields.ReturnCurve;
+  }
+
   // SimplexRidgeNoise2D/3D → Abs(SimplexNoise2D/3D) compound node
   if (internalType === "SimplexRidgeNoise2D" || internalType === "SimplexRidgeNoise3D") {
     const baseNoiseType = internalType === "SimplexRidgeNoise2D" ? "SimplexNoise2D" : "SimplexNoise3D";

--- a/src/utils/jsonToGraph.ts
+++ b/src/utils/jsonToGraph.ts
@@ -104,6 +104,10 @@ const FIELD_CATEGORY_PREFIX: Record<string, string> = {
   Material: "Material",
   ThicknessFunctionXZ: "",
   NewYAxis: "Vector",
+  // Curve fields on non-CurveFunction parents (e.g. PositionsCellNoise, Shell)
+  ReturnCurve: "Curve",
+  AngleCurve: "Curve",
+  DistanceCurve: "Curve",
 };
 
 /**


### PR DESCRIPTION
## Summary
- Normalizes both Hytale format variants (object `ReturnType` wrapper and flat `Curve` field) into a unified `ReturnCurve` internal field during import
- Adds `ReturnCurve`, `AngleCurve`, `DistanceCurve` to `FIELD_CATEGORY_PREFIX` so nested curves resolve as `Curve:Manual` instead of bare `Manual`
- Registers a `ReturnCurve` curve input handle on `PositionsCellNoise` so edges are visible and connectable
- Reverses the `ReturnCurve` → `Curve` rename on export for valid Hytale-native output

## Test plan
- [ ] Import a biome file containing `PositionsCellNoise` with a `Curve` return type (e.g. TropicalPirateIslandsBiome.json)
- [ ] Verify the Manual curve node renders as `Curve:Manual` with editable CurveCanvas and point list
- [ ] Verify the edge from Manual curve to PositionsCellNoise is visible via the `Return Curve` handle
- [ ] Re-export the file and confirm `ReturnCurve` is written back as `Curve` in the output JSON