### PR TITLE
Fix: FieldFunction MaterialProvider delimiters not displayed as nodes

### DIFF
--- a/src/components/properties/PropertyPanel.tsx
+++ b/src/components/properties/PropertyPanel.tsx
@@ -407,6 +407,61 @@ export function PropertyPanel() {
             </FieldWrapper>
           );
         }
+        if (Array.isArray(value) && key === "DelimiterRanges") {
+          const ranges = value as { From?: number; To?: number }[];
+          return (
+            <FieldWrapper key={key} issue={issue} helpMode={helpMode} onHelpClick={handleHelpClick} extendedDesc={isExpanded ? extendedDesc : undefined}>
+              <ArrayField
+                label={fieldLabel}
+                values={ranges}
+                description={description}
+                renderItem={(item, index) => {
+                  const range = item as { From?: number; To?: number };
+                  return (
+                    <div className="flex items-center gap-1.5 py-0.5">
+                      <span className="text-[10px] text-tn-text-muted w-4 shrink-0">[{index}]</span>
+                      <label className="text-[10px] text-tn-text-muted shrink-0">From</label>
+                      <input
+                        type="number"
+                        step="any"
+                        value={range.From ?? 0}
+                        onChange={(e) => {
+                          const v = parseFloat(e.target.value);
+                          if (Number.isNaN(v)) return;
+                          const newRanges = ranges.map((r, i) => i === index ? { ...r, From: v } : r);
+                          handleContinuousChange("DelimiterRanges", newRanges);
+                        }}
+                        onBlur={handleBlur}
+                        className="w-16 shrink-0 px-1.5 py-0.5 text-xs bg-tn-bg border border-tn-border rounded text-right"
+                      />
+                      <label className="text-[10px] text-tn-text-muted shrink-0">To</label>
+                      <input
+                        type="number"
+                        step="any"
+                        value={range.To ?? 1000}
+                        onChange={(e) => {
+                          const v = parseFloat(e.target.value);
+                          if (Number.isNaN(v)) return;
+                          const newRanges = ranges.map((r, i) => i === index ? { ...r, To: v } : r);
+                          handleContinuousChange("DelimiterRanges", newRanges);
+                        }}
+                        onBlur={handleBlur}
+                        className="w-16 shrink-0 px-1.5 py-0.5 text-xs bg-tn-bg border border-tn-border rounded text-right"
+                      />
+                    </div>
+                  );
+                }}
+                onAdd={() => {
+                  const lastTo = ranges.length > 0 ? (ranges[ranges.length - 1].To ?? 0) : 0;
+                  handleDiscreteChange("DelimiterRanges", [...ranges, { From: lastTo, To: lastTo + 25 }]);
+                }}
+                onRemove={(index) => {
+                  handleDiscreteChange("DelimiterRanges", ranges.filter((_, i) => i !== index));
+                }}
+              />
+            </FieldWrapper>
+          );
+        }
         if (Array.isArray(value)) {
           if (isManualCurve && key === "Points") {
             return (

--- a/src/nodes/index.ts
+++ b/src/nodes/index.ts
@@ -53,7 +53,7 @@ import {
   ConditionalMaterialNode, BlendMaterialNode, HeightGradientMaterialNode,
   NoiseSelectorMaterialNode, SolidMaterialNode, EmptyMaterialNode,
   SurfaceMaterialNode, CaveMaterialNode, ClusterMaterialNode,
-  ImportedMaterialNode, ExportedMaterialNode,
+  ImportedMaterialNode, ExportedMaterialNode, FieldFunctionMaterialNode,
   ConstantThicknessNode, NoiseThicknessNode, RangeThicknessNode, WeightedThicknessNode,
 } from "./material";
 
@@ -287,6 +287,7 @@ export const nodeTypes: Record<string, ComponentType<any>> = {
   "Material:Surface": SurfaceMaterialNode,
   "Material:Cave": CaveMaterialNode,
   "Material:Cluster": ClusterMaterialNode,
+  "Material:FieldFunction": FieldFunctionMaterialNode,
   "Material:Imported": ImportedMaterialNode,
   "Material:Exported": ExportedMaterialNode,
   // Layer sub-asset types (SpaceAndDepth V2)

--- a/src/nodes/material/MaterialNodes.tsx
+++ b/src/nodes/material/MaterialNodes.tsx
@@ -297,6 +297,34 @@ export const ExportedMaterialNode = memo(function ExportedMaterialNode(props: Ty
   );
 });
 
+/* ── FieldFunction MaterialProvider ─────────────────────────────────── */
+
+export const FieldFunctionMaterialNode = memo(function FieldFunctionMaterialNode(props: TypedNodeProps) {
+  const data = props.data;
+  const handles = useCompoundHandles(props.id, "Material:FieldFunction");
+  const ranges = (data.fields.DelimiterRanges as Array<{ From?: number; To?: number }>) ?? [];
+  return (
+    <BaseNode
+      {...props}
+      category={AssetCategory.MaterialProvider}
+      handles={handles}
+    >
+      {ranges.length > 0 ? (
+        <div className="space-y-0.5">
+          {ranges.map((r, i) => (
+            <div key={i} className="flex items-center justify-between text-[10px]">
+              <span className="text-tn-text-muted">[{i}]</span>
+              <span>{safeDisplay(r.From, 0)} → {safeDisplay(r.To, 0)}</span>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="text-tn-text-muted text-[10px] text-center py-0.5">No delimiters</div>
+      )}
+    </BaseNode>
+  );
+});
+
 /* ── Layer sub-asset nodes (SpaceAndDepth V2) ──────────────────────── */
 
 export const ConstantThicknessNode = memo(function ConstantThicknessNode(props: TypedNodeProps) {

--- a/src/nodes/material/index.ts
+++ b/src/nodes/material/index.ts
@@ -13,6 +13,7 @@ export {
   ClusterMaterialNode,
   ImportedMaterialNode,
   ExportedMaterialNode,
+  FieldFunctionMaterialNode,
   // Layer sub-asset nodes (SpaceAndDepth V2)
   ConstantThicknessNode,
   NoiseThicknessNode,

--- a/src/nodes/shared/compoundPorts.ts
+++ b/src/nodes/shared/compoundPorts.ts
@@ -61,6 +61,7 @@ export const COMPOUND_PORTS: Record<string, CompoundPortConfig> = {
   "Material:WeightedRandom": { arrayBase: "Entries",   label: "Entry",    category: AssetCategory.MaterialProvider, minSlots: 2 },
   "Material:Queue":          { arrayBase: "Queue",     label: "Material", category: AssetCategory.MaterialProvider, minSlots: 2 },
   "Material:Striped":        { arrayBase: "Materials", label: "Material", category: AssetCategory.MaterialProvider, minSlots: 2 },
+  "Material:FieldFunction":  { arrayBase: "Materials", label: "Material", category: AssetCategory.MaterialProvider, minSlots: 1 },
   "Material:SpaceAndDepth":  { arrayBase: "Layers",   label: "Layer",    category: AssetCategory.MaterialProvider, minSlots: 2 },
   "Material:NoiseSelectorMaterial": { arrayBase: "Inputs", label: "Input", category: AssetCategory.MaterialProvider, minSlots: 2 },
   "Material:NoiseSelector":         { arrayBase: "Inputs", label: "Input", category: AssetCategory.MaterialProvider, minSlots: 2 },

--- a/src/utils/jsonToGraph.ts
+++ b/src/utils/jsonToGraph.ts
@@ -102,6 +102,7 @@ const FIELD_CATEGORY_PREFIX: Record<string, string> = {
   // Layer sub-assets within SpaceAndDepth
   Layers: "Material",
   Material: "Material",
+  Materials: "Material",
   ThicknessFunctionXZ: "",
   NewYAxis: "Vector",
   // Curve fields on non-CurveFunction parents (e.g. PositionsCellNoise, Shell)


### PR DESCRIPTION
## Summary

- **Import**: Standalone FieldFunction MaterialProviders with Delimiters are now extracted into `Materials[]` compound handles (for material connections) and `DelimiterRanges[]` (for editable From/To ranges), instead of falling through as raw JSON
- **Export**: `Materials[]` + `DelimiterRanges[]` are zipped back into Hytale's native `Delimiters[{From, To, Material}]` format for lossless round-trip
- **Node component**: Dedicated `FieldFunctionMaterialNode` with compound material handles and inline delimiter range display (`[0] 0 → 35`, etc.)
- **PropertyPanel**: `DelimiterRanges` now renders as individual editable From/To number inputs per entry with Add/Remove controls, replacing the raw JSON fallback

## Files Changed (8)

| File | Change |
|------|--------|
| `src/utils/hytaleToInternal.ts` | `reverseFieldFunctionMaterialDelimiters()` + detection |
| `src/utils/internalToHytale.ts` | `transformFieldFunctionMaterialWithDelimiters()` + detection |
| `src/utils/jsonToGraph.ts` | `Materials: "Material"` in FIELD_CATEGORY_PREFIX |
| `src/nodes/shared/compoundPorts.ts` | Register Material:FieldFunction compound port |
| `src/nodes/material/MaterialNodes.tsx` | FieldFunctionMaterialNode component |
| `src/nodes/material/index.ts` | Export new component |
| `src/nodes/index.ts` | Register in nodeTypes map |
| `src/components/properties/PropertyPanel.tsx` | Editable DelimiterRanges renderer |

## Test plan

- [ ] Open a file with FieldFunction MaterialProvider + Delimiters (e.g. Plastic3_B) — each delimiter's Material appears as a proper `Material:Constant` node connected via `Materials[0]`, `Materials[1]`, etc.
- [ ] Select the FieldFunction node — PropertyPanel shows editable From/To number inputs per delimiter with Add/Remove buttons
- [ ] Edit From/To values in PropertyPanel — changes reflect on node body and persist through save
- [ ] Add/remove delimiter ranges via PropertyPanel buttons
- [ ] Round-trip: open file → save/export → verify output JSON matches original FieldFunction + Delimiters structure
- [ ] Queue[FieldFunction] files continue importing as Conditional chains (existing path unaffected)
- [ ] All existing tests pass (818/818 non-pre-existing)

Closes #30