### PR TITLE
fix: graph flow direction edge connections

### DIFF
--- a/src/components/editor/EditorCanvas.tsx
+++ b/src/components/editor/EditorCanvas.tsx
@@ -211,11 +211,14 @@ export function EditorCanvas() {
       try {
         const layouted = await autoLayout(nodes, edges, flowDirection);
         useEditorStore.getState().setNodes(layouted);
-        // Force React Flow to re-read handle positions from the DOM so edges route correctly
-        setTimeout(() => {
-          updateNodeInternals(layouted.map((n) => n.id));
-          reactFlowInstance.fitView({ padding: 0.1, duration: 300 });
-        }, 50);
+        // Double rAF ensures React's commit phase is done and the browser has painted,
+        // so updateNodeInternals reads the correct handle positions from the DOM.
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => {
+            updateNodeInternals(layouted.map((n) => n.id));
+            reactFlowInstance.fitView({ padding: 0.1, duration: 300 });
+          });
+        });
       } catch (err) {
         if (import.meta.env.DEV) console.error("Auto layout failed (flow direction change):", err);
       }


### PR DESCRIPTION
## Summary

- Fixes edge connection points (handles) visually staying on the wrong side when switching graph flow direction (LR ↔ RL)
- Replaces unreliable `setTimeout(..., 50)` with double `requestAnimationFrame` pattern to ensure React has committed DOM updates and the browser has painted before `updateNodeInternals()` reads handle positions

## Test plan

- [ ] Open/create a graph with connected nodes
- [ ] Switch flow direction from "Left to Right" to "Right to Left" in Settings > Preferences
- [ ] Confirm nodes reposition AND edges connect to the correct side of the handles
- [ ] Switch back to "Left to Right" — same check
- [ ] Test with the toolbar quick-toggle ("Flow Direction: LTR/RTL")
- [ ] Verify edges remain correct after undo/redo and after reopening the project

Fixes #44