### PR TITLE
fix: macOS Apple Silicon apps don't launch (Gatekeeper "damaged" error)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,11 @@ jobs:
             **macOS**
             1. Download the `.dmg` for your architecture (aarch64 = Apple Silicon, x86_64 = Intel)
             2. Open the `.dmg` and drag TerraNova to Applications
-            3. On first launch, right-click → Open (macOS may block unsigned apps)
+            3. **First launch:** Right-click (or Control-click) TerraNova → select "Open" → click "Open" in the dialog
+            4. If macOS still blocks the app, open Terminal and run:
+               `xattr -cr /Applications/TerraNova.app` then launch normally
+            5. Alternatively: **System Settings → Privacy & Security** → click "Open Anyway"
+            > TerraNova is not yet signed with an Apple Developer certificate. The steps above are only needed once.
             > Requires macOS 10.15+.
 
             **Linux**
@@ -115,3 +119,13 @@ jobs:
           releaseDraft: false
           prerelease: true
           args: ${{ matrix.rust_target != '' && format('--target {0}', matrix.rust_target) || '' }}
+
+      - name: Verify macOS code signature
+        if: runner.os == 'macOS'
+        run: |
+          APP_PATH=$(find src-tauri/target -name "TerraNova.app" -type d | head -1)
+          if [ -n "$APP_PATH" ]; then
+            echo "Verifying signature on: $APP_PATH"
+            codesign -dvv "$APP_PATH" 2>&1
+            codesign --verify --deep --strict "$APP_PATH" 2>&1 || echo "Warning: Signature verification had issues"
+          fi

--- a/README.md
+++ b/README.md
@@ -42,6 +42,31 @@
 3. Design your worldgen using the node editor and live preview
 4. Export and drop the JSON files in your server's `mods/` folder
 
+<details>
+<summary><strong>macOS: App Won't Open / "Unverified Developer"</strong></summary>
+
+TerraNova is not yet signed with an Apple Developer certificate. macOS may block the app on first launch. Use one of these methods:
+
+**Method 1 — Right-click Open (recommended)**
+1. Right-click (or Control-click) TerraNova in Applications
+2. Select "Open" from the context menu
+3. Click "Open" in the dialog that appears
+
+**Method 2 — Terminal command**
+```bash
+xattr -cr /Applications/TerraNova.app
+```
+Then launch normally.
+
+**Method 3 — System Settings**
+1. Open **System Settings → Privacy & Security**
+2. Scroll to the Security section — you'll see a message about TerraNova being blocked
+3. Click **"Open Anyway"**
+
+> These steps are only needed once. Subsequent launches will work normally.
+
+</details>
+
 ## Keyboard Shortcuts
 
 | Shortcut | Action |

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3970,7 +3970,7 @@ dependencies = [
 
 [[package]]
 name = "terranova"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "fastnoise-lite",
  "reqwest 0.12.28",

--- a/src-tauri/Entitlements.plist
+++ b/src-tauri/Entitlements.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+</dict>
+</plist>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -48,6 +48,11 @@
         "installMode": "currentUser",
         "displayLanguageSelector": false
       }
+    },
+    "macOS": {
+      "signingIdentity": "-",
+      "minimumSystemVersion": "10.15",
+      "entitlements": "./Entitlements.plist"
     }
   },
   "plugins": {


### PR DESCRIPTION
## Summary

- Add ad-hoc code signing (`signingIdentity: "-"`) to macOS builds via Tauri's bundle config, fixing the unrecoverable "damaged and can't be opened" Gatekeeper error on Apple Silicon
- Create `Entitlements.plist` with JIT and unsigned executable memory permissions required by WKWebView's JavaScript engine
- Expand macOS installation instructions in release notes and README with three workaround methods for the "unverified developer" dialog
- Add CI step to verify code signature on macOS builds for diagnostic purposes

## Context

Users downloading TerraNova `.dmg` from GitHub Releases on macOS Apple Silicon get a Gatekeeper error ("TerraNova is damaged and can't be opened") because the app has no code signature at all. On Apple Silicon, the kernel requires at minimum an ad-hoc signature for code integrity checks. The existing "right-click > Open" workaround does **not** work for this "damaged" error variant.

With ad-hoc signing, the error changes from the unrecoverable "damaged" message to the bypassable "unverified developer" dialog, which users can dismiss via right-click > Open.

## Test plan

- [ ] Build locally with `pnpm tauri build` and verify `.app` is ad-hoc signed: `codesign -dvv src-tauri/target/release/bundle/macos/TerraNova.app` should show `Signature=adhoc`
- [ ] Copy `.app` to `/Applications`, add quarantine attribute (`xattr -w com.apple.quarantine "0083;66abc123;Safari;" /Applications/TerraNova.app`), double-click — should show "unverified developer" (bypassable), NOT "damaged and can't be opened"
- [ ] Right-click > Open should launch successfully
- [ ] Verify CI release workflow passes on macOS runners
- [ ] Verify existing auto-updater relaunch logic (`process.rs`) still works (it already does `codesign --sign -` post-update)

Closes #45